### PR TITLE
Chore/bump dependencies

### DIFF
--- a/barebones/package.json
+++ b/barebones/package.json
@@ -14,15 +14,15 @@
 	"devDependencies": {
 		"@floating-ui/dom": "^1.6.3",
 		"@skeletonlabs/skeleton": "^2.8.0",
-		"@skeletonlabs/tw-plugin": "^0.3.1",
+		"@skeletonlabs/tw-plugin": "^0.4.0",
 		"@sveltejs/adapter-auto": "^3.1.1",
 		"@sveltejs/kit": "^2.5.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.2",
 		"@types/node": "^20.11.19",
-		"@typescript-eslint/eslint-plugin": "^6.21.0",
-		"@typescript-eslint/parser": "^6.21.0",
+		"@typescript-eslint/eslint-plugin": "^7.7.0",
+		"@typescript-eslint/parser": "^7.7.0",
 		"autoprefixer": "^10.4.17",
-		"eslint": "^8.56.0",
+		"eslint": "^8.56.1",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.35.1",
 		"highlight.js": "^11.9.0",
@@ -35,7 +35,7 @@
 		"tslib": "^2.6.2",
 		"typescript": "^5.3.3",
 		"vite": "^5.1.3",
-		"vite-plugin-tailwind-purgecss": "^0.2.0"
+		"vite-plugin-tailwind-purgecss": "^0.3.1"
 	},
 	"type": "module"
 }

--- a/welcome/package.json
+++ b/welcome/package.json
@@ -14,17 +14,17 @@
 	"devDependencies": {
 		"@floating-ui/dom": "^1.6.3",
 		"@skeletonlabs/skeleton": "^2.8.0",
-		"@skeletonlabs/tw-plugin": "^0.3.1",
+		"@skeletonlabs/tw-plugin": "^0.4.0",
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@tailwindcss/forms": "^0.5.7",
 		"@tailwindcss/typography": "^0.5.10",
 		"@types/node": "^20.11.19",
-		"@typescript-eslint/eslint-plugin": "^6.21.0",
-		"@typescript-eslint/parser": "^6.21.0",
+		"@typescript-eslint/eslint-plugin": "^7.7.0",
+		"@typescript-eslint/parser": "^7.7.0",
 		"autoprefixer": "^10.4.17",
-		"eslint": "^8.56.0",
+		"eslint": "^8.57.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.35.1",
 		"highlight.js": "^11.9.0",
@@ -37,7 +37,7 @@
 		"tslib": "^2.6.2",
 		"typescript": "^5.3.3",
 		"vite": "^5.0.0",
-		"vite-plugin-tailwind-purgecss": "^0.2.0"
+		"vite-plugin-tailwind-purgecss": "^0.3.1"
 	},
 	"type": "module"
 }


### PR DESCRIPTION
- chore: Update barebones dependencies. (peer issues with eslint version 9 -- bumped to 8.57.0)
- chore: Update welcome dependencies. (peer issues with eslint version 9 -- bumped to 8.57.0)